### PR TITLE
Add get_state to skill and remove name method

### DIFF
--- a/skills.py
+++ b/skills.py
@@ -1,29 +1,26 @@
 from utils import Skill
 
 class TurnLightsOn(Skill):
-    def name(self):
-        return "TurnLightsOn"
-
     def description(self):
         return "Turns the lights on to full brightness in the room."
     
     def do_skill(self):
         return "Turning lights on"
 
-class TurnLightsOff(Skill):
-    def name(self):
-        return "TurnLightsOff"
+    def get_state(self):
+        return "Lights are disconnected"
 
+class TurnLightsOff(Skill):
     def description(self):
         return "Turns the lights off in the room."
     
     def do_skill(self):
         return "Turning lights off"
 
-class PlayMusic(Skill):
-    def name(self):
-        return "PlayMusic"
+    def get_state(self):
+        return "Lights are off"
 
+class PlayMusic(Skill):
     def description(self):
         return "Plays music from a playlist."
     
@@ -31,9 +28,6 @@ class PlayMusic(Skill):
         return "Playing music"
 
 class StopMusic(Skill):
-    def name(self):
-        return "StopMusic"
-
     def description(self):
         return "Stops playing music."
     

--- a/utils.py
+++ b/utils.py
@@ -24,15 +24,6 @@ class Skill(ABC):
     """
 
     @abstractmethod
-    def name(self):
-        """Gets the name of this Skill function.
-        
-        Returns:
-            The name of this Skill
-        """
-        pass
-
-    @abstractmethod
     def description(self):
         """A description of this Skill function.
 
@@ -57,6 +48,18 @@ class Skill(ABC):
         Returns:
             A string representing the outcome of this running this skill.  For
             example, this could be a success, error, or state message.
+        """
+        pass
+
+    def get_state(self):
+        """Get the state of this skill.
+        
+        This method is called occasionally to get the state of this skill.  This
+        state is then passed to the model when it is deciding what function to
+        call.  This method is optional and is not called if not implemented.
+
+        Returns:
+            A string representing the state of this skill.
         """
         pass
 
@@ -88,8 +91,7 @@ class SkillHelper:
             params: (optional) a dictionary mapping parameter names to values
         """
         for s in self.skills:
-            if s.name() == skill:
-                # TODO: implement better argument parsing
+            if s.__class__.__name__ == skill:
                 return s.do_skill(**params)
         raise Exception('Skill name: {skill} not found')
 
@@ -99,7 +101,6 @@ class SkillHelper:
         Returns:
             A dictionary of all skills formatted as OpenAI functions
         """
-        # TODO: for now, I'm not supporting parameters in functions
         skill_funcs = []
         for s in self.skills:
             params = {}
@@ -116,7 +117,7 @@ class SkillHelper:
                     params[key] = {}
 
             skill_funcs.append({
-                    "name": s.name(),
+                    "name": s.__class__.__name__,
                     "description": s.description(),
                     "parameters": {
                         "type": "object",
@@ -125,6 +126,19 @@ class SkillHelper:
                     },
                 })
         return skill_funcs
+
+    def get_state(self):
+        """Get the state of all skills.
+        
+        Returns:
+            A dictionary mapping skill names to their states
+        """
+        states = {}
+        for s in self.skills:
+            state = s.get_state()
+            if state:
+                states[s.__class__.__name__] = state
+        return states
 
 
 SYSTEM_MESSAGE = {


### PR DESCRIPTION
The `name` method of Skill is redundant as that can be found using `__class__.__name__`, so removed it and replaced it. Additionally, we will need to allow Bobby to know the current state of the environment - added an optional `get_state` method to `Skill` that can be overridden. Finally, added a `get_states` method to `SkillHelper` that gets the state from each skill. In the future we might need to implement some sort of error or timeout handling for that method.